### PR TITLE
Fix 'GLEstimator' object has no attribute '__sklearn_tags__'

### DIFF
--- a/glest/__init__.py
+++ b/glest/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.1-alpha.1"
+__version__ = "0.0.1"
 
 from .core import GLEstimator, GLEstimatorCV, Partitioner

--- a/glest/core.py
+++ b/glest/core.py
@@ -18,11 +18,11 @@ from .helpers import (
 )
 from .plot import grouping_diagram
 from sklearn.utils.validation import indexable
-from sklearn.base import clone
+from sklearn.base import clone, BaseEstimator
 from typing import List
 
 
-class Partitioner:
+class Partitioner(BaseEstimator):
     """A class for partitionning the feature space, stratified by level sets
     of predicted probabilities.
 
@@ -327,7 +327,7 @@ class Partitioner:
         return labels
 
 
-class GLEstimator:
+class GLEstimator(BaseEstimator):
     """Estimate the grouping loss of a fitted probabilistic classifier.
 
     Parameters


### PR DESCRIPTION
Should fix #9.

Inherit from BaseEstimator for compatibility with sklearn 1.7